### PR TITLE
fix: don't create index write memcached

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1218,6 +1218,27 @@ memcached:
   #             values:
   #             - metrics-enterprise-memcached
 
+# Chunks index-write cache.
+memcached-index-write:
+  enabled: false
+  replicaCount: 2
+  #pdbMinAvailable: 1
+  #image: memcached:1.5.7-alpine
+  memcached:
+    maxItemMemory: 3840
+    extraArgs:
+      - -I 32m
+    threads: 32
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 10m
+    limits:
+      memory: 4Gi
+      cpu: 1
+  metrics:
+    enabled: true
+
 # Blocks/chunks index read cache.
 memcached-index-read:
   enabled: true


### PR DESCRIPTION
Resolves #14 
It's not needed for blocks clusters and is enabled by default because of how Chart dependencies are handled.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>