### PR TITLE
fix: Add policy and purge configuration to minio buckets

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1287,9 +1287,15 @@ minio:
   enabled: true
   accessKey: metrics-enterprise
   secretKey: supersecret
+  persistence:
+    size: 25Gi
   buckets:
     - name: metrics-enterprise-tsdb
+      policy: none
+      purge: false
     - name: metrics-enterprise-admin
+      policy: none
+      purge: false
 
 consul:
   enabled: true


### PR DESCRIPTION
Resolves #15 
If these values are not set, the minio-make-bucket job will create the
buckets but will ultimately error.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>